### PR TITLE
FIX: background for textInput

### DIFF
--- a/assets/scss/base/_forms.scss
+++ b/assets/scss/base/_forms.scss
@@ -93,6 +93,7 @@
     input:not([type=submit]):not([type=reset]):not([type=radio]):not([type=checkbox]) {
         width: calc(98% - 2px);
         padding: 0 1%;
+        background: #e0e0e0;
     }
     textarea {
         width: calc(98% - 2px);


### PR DESCRIPTION
Ajout de background par défaut sur les input afin d'éviter une modification par le thème d'Ubuntu/autre
Exemple: avec un thème sombre le texte s'écrivait noir sur noir

Rafraichissement du cache style requis


### Contrôle qualité

Vérifier avec un thème Ubuntu :)
